### PR TITLE
Added functionality: Keep oldest scroll positions

### DIFF
--- a/src/components/restorescroll.ts
+++ b/src/components/restorescroll.ts
@@ -594,19 +594,29 @@ export class RestoreScroll {
 
     /**
      * Limits the number of stored file states by timestamp and discards the newest.
+     * but will allow existing file states to be updated.
      */
     private discardNewStates() {
         const entries = Object.entries(this.ephemeralStates);
+        const limit = this.plugin.settings.restoreScrollLimit;
+
         if (
-            this.plugin.settings.restoreScrollLimit <= 0 ||
-            entries.length <= this.plugin.settings.restoreScrollLimit
+            limit <= 0 ||
+            entries.length <= limit
         )
             return;
 
         entries.sort(([, a], [, b]) => a.timestamp - b.timestamp);
+        
+        const oldestStates = entries.slice(0, limit);
+        const newestStates = entries.slice(limit);
+    
+        // Update states of existing old files to register new scroll positions
+        const statesToKeep = new Map(oldestStates);
+        for (const [fileTitle, state] of newestStates) {
+            if (statesToKeep.has(fileTitle)) statesToKeep.set(fileTitle, state);
+        }
 
-        this.ephemeralStates = Object.fromEntries(
-            entries.slice(0, this.plugin.settings.restoreScrollLimit),
-        );
+        this.ephemeralStates = Object.fromEntries(statesToKeep.entries());
     }
 }

--- a/src/components/restorescroll.ts
+++ b/src/components/restorescroll.ts
@@ -567,7 +567,11 @@ export class RestoreScroll {
             if (scrollTop) this.ephemeralStates[fileId] = { timestamp, scrollTop };
         }
 
-        this.discardOldStates();
+        if (this.plugin.settings.restoreScrollAge) {
+            this.discardNewStates();
+        } else {
+            this.discardOldStates();
+        }
     }
 
     /**
@@ -582,6 +586,24 @@ export class RestoreScroll {
             return;
 
         entries.sort(([, a], [, b]) => b.timestamp - a.timestamp);
+
+        this.ephemeralStates = Object.fromEntries(
+            entries.slice(0, this.plugin.settings.restoreScrollLimit),
+        );
+    }
+
+    /**
+     * Limits the number of stored file states by timestamp and discards the newest.
+     */
+    private discardNewStates() {
+        const entries = Object.entries(this.ephemeralStates);
+        if (
+            this.plugin.settings.restoreScrollLimit <= 0 ||
+            entries.length <= this.plugin.settings.restoreScrollLimit
+        )
+            return;
+
+        entries.sort(([, a], [, b]) => a.timestamp - b.timestamp);
 
         this.ephemeralStates = Object.fromEntries(
             entries.slice(0, this.plugin.settings.restoreScrollLimit),

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -23,6 +23,10 @@ export interface ScrollingPluginSettings {
     restoreScrollMode: string;
     /** Number of scroll position entries. Use negative values to ignore the limit. */
     restoreScrollLimit: number;
+    
+    /** Choose to keep scroll positions of the oldest entries instead of most recent (default) */
+    restoreScrollAge: boolean;
+
     /** Delay before restoring the position in ms. (0-300) */
     restoreScrollDelay: number;
     /** Enable scroll position in pdf files. */
@@ -114,6 +118,7 @@ export const DEFAULT_SETTINGS: ScrollingPluginSettings = {
 
     restoreScrollMode: "top",
     restoreScrollLimit: -1,
+    restoreScrollAge: false,
     restoreScrollDelay: 5,
     restoreScrollPdf: false,
     restoreScrollBases: false,
@@ -465,17 +470,42 @@ export class ScrollingSettingTab extends PluginSettingTab {
                         ? this.plugin.settings.restoreScrollLimit.toString()
                         : "",
                 )
-                .onChange((value: string) => {
+                .onChange(async (value: string) => {
                     const limit = +value;
                     if (limit.toString().contains(".")) return;
-                    if (limit <= 0) {
+                    
+                    if (limit <= 0 || isNaN(limit)) {
                         this.plugin.settings.restoreScrollLimit = -1;
-                        return;
+                    } else {
+                        this.plugin.settings.restoreScrollLimit = limit;
                     }
 
-                    this.plugin.settings.restoreScrollLimit = limit;
+                    await this.plugin.saveSettings();
+
+                    if (restoreScrollAgeSetting) {
+                        const shouldShow = this.plugin.settings.restoreScrollLimit > 0;
+                        // Collapse the space entirely by modifying 'display'
+                        restoreScrollAgeSetting.settingEl.style.display = shouldShow ? "" : "none";
+                    }
                 });
         });
+
+        const restoreScrollAgeSetting = this.createSetting(
+            "Keep oldest scroll positions",
+            "When the limit is reached, keep the oldest saved positions instead of the most recent ones (default).",
+            () => (this.plugin.settings.restoreScrollAge = DEFAULT_SETTINGS.restoreScrollAge),
+            ).addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.restoreScrollAge)
+                    .onChange(async (value) => {
+                        this.plugin.settings.restoreScrollAge = value;
+                        await this.plugin.saveSettings();
+                }),
+        );
+
+        const initialShow = this.plugin.settings.restoreScrollLimit > 0;
+        restoreScrollAgeSetting.settingEl.style.display = initialShow ? "" : "none";
+
 
         if (Platform.isMobile) {
             this.createSetting(


### PR DESCRIPTION
Added functionality: when "saved positions limit" settings is set, a toggle option appears that lets user select to keep the oldest saved positions, not the most recent ones as the default suggests.